### PR TITLE
Compiling Error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
     repositories {
+        google()
         jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
-        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'


### PR DESCRIPTION
A problem occurred configuring project ':react-native-snackbar'.
> Could not resolve all artifacts for configuration ':react-native-snackbar:classpath'.
   > Could not find aapt2-proto.jar (com.android.tools.build:aapt2-proto:0.3.1).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/aapt2-proto/0.3.1/aapt2-proto-0.3.1.jar